### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://appaja.visualstudio.com/c610ee16-3a61-4653-a28a-a639058d06d1/329bfe54-7788-4273-90d8-228ce222dde1/_apis/work/boardbadge/ca93e31d-4288-4658-a133-b70a9c811098)](https://appaja.visualstudio.com/c610ee16-3a61-4653-a28a-a639058d06d1/_boards/board/t/329bfe54-7788-4273-90d8-228ce222dde1/Microsoft.RequirementCategory)
 # BikeApp
 This repository is used to collect bug and feature request


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#135](https://appaja.visualstudio.com/c610ee16-3a61-4653-a28a-a639058d06d1/_workitems/edit/135). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.